### PR TITLE
Added MacOS brew dependency to libmagic

### DIFF
--- a/install_macos_silicon.sh
+++ b/install_macos_silicon.sh
@@ -25,7 +25,7 @@ echo "Updating Homebrew..."
 brew update
 
 echo "Installing system dependencies (ffmpeg and poppler)..."
-brew install ffmpeg poppler
+brew install ffmpeg poppler libmagic
 
 echo "System dependencies installed successfully."
 


### PR DESCRIPTION
Libmagic is required in order to run the application but is missing in the install_macos_silicon.sh script.
This is the message I got when I tried to run the app before installing the dependency:

`Traceback (most recent call last):
  File "/Users/murkrow/Desktop/TRACE-Forensic-Toolkit/main.py", line 3, in <module>
    from modules.mainwindow import MainWindow
  File "/Users/murkrow/Desktop/TRACE-Forensic-Toolkit/modules/mainwindow.py", line 21, in <module>
    from modules.metadata_tab import MetadataViewer
  File "/Users/murkrow/Desktop/TRACE-Forensic-Toolkit/modules/metadata_tab.py", line 5, in <module>
    from magic import Magic
  File "/Users/murkrow/Desktop/TRACE-Forensic-Toolkit/venv/lib/python3.9/site-packages/magic/__init__.py", line 209, in <module>
    libmagic = loader.load_lib()
  File "/Users/murkrow/Desktop/TRACE-Forensic-Toolkit/venv/lib/python3.9/site-packages/magic/loader.py", line 49, in load_lib
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation`

This was simply solved with `brew install libmagic`