### PR TITLE
fixed a bug that could be encountered during macos Apple Silicon installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # Ignore virtual environment folders
 /venv/
+
+# Ignore Python cache
+__pycache__

--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ pip install -r requirements.txt
 
 
 #### For macOS - Apple Silicon:
+
+Create a virtual environment with python 3.11
+
+```bash
+python3.11 -m venv venv
+source venv/bin/activate
+```
+
 ```bash
 chmod +x install_macos_silicon.sh
  ```

--- a/install_macos_silicon.sh
+++ b/install_macos_silicon.sh
@@ -25,7 +25,7 @@ echo "Updating Homebrew..."
 brew update
 
 echo "Installing system dependencies (ffmpeg and poppler)..."
-brew install ffmpeg poppler
+brew install ffmpeg poppler libmagic
 
 echo "System dependencies installed successfully."
 


### PR DESCRIPTION
Hello
I tried to install this program on my M1 pro mac
i noticed that you were missing a brew dependency and i added it (i couldn't install without it).
also i added instructions to tell people to use a venv with python 3.11 since i think now lots of people could be using python 3.13 and also it's a good practice to use a venv